### PR TITLE
Fix heading level issue

### DIFF
--- a/src/content/learn/importing-and-exporting-components.md
+++ b/src/content/learn/importing-and-exporting-components.md
@@ -247,7 +247,7 @@ Tällä sivulla opit:
 
 <Challenges>
 
-### Jaa komponentteja edelleen {/*split-the-components-further*/}
+#### Jaa komponentteja edelleen {/*split-the-components-further*/}
 
 Tällä hetkellä `Gallery.js` exporttaa molemmat `Profile`:n sekä `Gallery`:n, joka on hieman sekavaa.
 

--- a/src/content/learn/javascript-in-jsx-with-curly-braces.md
+++ b/src/content/learn/javascript-in-jsx-with-curly-braces.md
@@ -337,7 +337,7 @@ body > div > div { padding: 20px; }
 
 </Solution>
 
-### Poimi tieto olioon {/*extract-information-into-an-object*/}
+#### Poimi tieto olioon {/*extract-information-into-an-object*/}
 
 Siirrä kuvan URL `person` olioon.
 
@@ -424,7 +424,7 @@ body > div > div { padding: 20px; }
 
 </Solution>
 
-### Kirjoita Write an expression inside JSX curly braces {/*write-an-expression-inside-jsx-curly-braces*/}
+#### Kirjoita Write an expression inside JSX curly braces {/*write-an-expression-inside-jsx-curly-braces*/}
 
 Alla olevassa oliossa kuvan URL osoite on rakennettu neljästä palasta: pohja URL, `imageId`, `imageSize` ja tiedostopäätteestä.
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
The third heading level caused an error on `JavaScript in JSX with curly braces`.

`TypeError: Cannot read properties of undefined (reading 'current') 
at src/components/MDX/Challenges/Navigation.tsx (68:44)`

Changing to the fourth heading level fixes this. This PR also fixes the heading level for `Importing and exporting components`, where the heading level caused scroll jumps.